### PR TITLE
Ensure arrows are rigid during animation

### DIFF
--- a/src/arrow_visualizer.jl
+++ b/src/arrow_visualizer.jl
@@ -1,23 +1,20 @@
 struct ArrowVisualizer{V<:AbstractVisualizer}
-    shaft_vis::V
-    head_vis::V
+    vis::V
 end
-
-ArrowVisualizer(vis::AbstractVisualizer) = ArrowVisualizer(vis[:shaft], vis[:head])
 
 function setobject!(vis::ArrowVisualizer, material::AbstractMaterial=defaultmaterial();
         shaft_material::AbstractMaterial=material,
         head_material::AbstractMaterial=material)
     settransform!(vis, zero(Point{3, Float64}), zero(Vec{3, Float64}))
     shaft = Cylinder(zero(Point{3, Float64}), Point(0.0, 0.0, 1.0), 1.0)
-    setobject!(vis.shaft_vis, shaft, shaft_material)
+    setobject!(vis.vis[:shaft], shaft, shaft_material)
     head = Cone(zero(Point{3, Float64}), Point(0.0, 0.0, 1.0), 1.0)
-    setobject!(vis.head_vis, head, head_material)
+    setobject!(vis.vis[:head], head, head_material)
     vis
 end
 
 function Base.show(io::IO, v::ArrowVisualizer)
-    print(io, "MeshCat ArrowVisualizer with paths $(v.shaft_vis.path) and $(v.head_vis.path).")
+    print(io, "MeshCat ArrowVisualizer with path $(v.vis.path)/arrow")
 end
 
 function settransform!(vis::ArrowVisualizer, base::Point{3}, vec::Vec{3};
@@ -34,13 +31,16 @@ function settransform!(vis::ArrowVisualizer, base::Point{3}, vec::Vec{3};
     shaft_length = max(vec_length - max_head_length, 0)
     shaft_scaling = LinearMap(Diagonal(SVector(shaft_radius, shaft_radius, shaft_length)))
     shaft_tform = Translation(base) ∘ rotation ∘ shaft_scaling
-    settransform!(vis.shaft_vis, shaft_tform)
+    settransform!(vis.vis, shaft_tform)
 
-    head_length = vec_length - shaft_length
-    head_radius = max_head_radius * head_length / max_head_length
-    head_scaling = LinearMap(Diagonal(SVector(head_radius, head_radius, head_length)))
-    head_tform = Translation(base) ∘ rotation ∘ Translation(shaft_length * Vec(0, 0, 1)) ∘ head_scaling
-    settransform!(vis.head_vis, head_tform)
+    if vec_length > eps(typeof(vec_length))
+        head_length = vec_length - shaft_length
+        head_radius = max_head_radius * head_length / max_head_length
+        head_scaling = LinearMap(Diagonal(SVector(head_radius, head_radius, head_length)))
+        head_tform = inv(shaft_scaling) ∘ Translation(shaft_length * Vec(0, 0, 1)) ∘ head_scaling
+        # head_tform = Translation(base) ∘ rotation ∘ Translation(shaft_length * Vec(0, 0, 1)) ∘ head_scaling
+        settransform!(vis.vis[:head], head_tform)
+    end
 
     vis
 end


### PR DESCRIPTION
This is an example of what I was talking about in https://github.com/rdeits/MeshCat.jl/pull/97#issuecomment-484753079 . We don't have to implement it in exactly this way, but the general idea is to transform the *whole* arrow, rather than transforming the shaft and head separately. That ensures that everything stays rigid, even during animations. 

Example: 

```julia
av = ArrowVisualizer(vis[:arrow])

setobject!(av)

settransform!(av, Point(0., 0, 0), Vec(1., 0, 0))

anim = Animation()
atframe(anim, vis[:arrow], 0) do frame
    settransform!(ArrowVisualizer(frame), Point(0., 0, 0), Vec(1., 0, 0))
end

atframe(anim, vis[:arrow], 30) do frame
    settransform!(ArrowVisualizer(frame), Point(0., 0, 0), Vec(0., 0, 0.2))
end
setanimation!(vis, anim)
```

Result:

![animation](https://user-images.githubusercontent.com/591886/56403603-144c2e80-6230-11e9-9d0d-ef8b31d78dcc.gif)
